### PR TITLE
update buffer size

### DIFF
--- a/src/execution_hash/main.eas
+++ b/src/execution_hash/main.eas
@@ -21,6 +21,47 @@
 ;; SYSADDR is the address which calls the contract to submit a new block hash.
 #define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)
 
+;; call ArbSys::arbBlockNumber()
+;; takes 0 stack arguments
+;; pushes the result onto the stack
+;; we can use memory however we like, because the "set" path doesn't use memory
+#define %arb_block_num() {
+  ;; stack input to staticcall
+  ;; gas
+  ;; address
+  ;; argsOffset: byte offset in the memory in bytes, the calldata of the sub context.
+  ;; argsSize: byte size to copy (size of the calldata).
+  ;; retOffset: byte offset in the memory in bytes, where to store the return data of the sub context.
+  ;; retSize: byte size to copy (size of the return data).
+
+  ;; retSize
+  push 32         ;; [retSize]
+  ;; retOffset
+  push0           ;; [retOffset, retSize]
+  ;; argsSize
+  push 4          ;; [argsSize, retOffset, retSize]
+  ;; argsOffset, we'll just overwrite memory at 0
+  push 28         ;; [argsOffset, argsSize, retOffset, retSize]
+  ;; address (ArbSys)
+  push 100        ;; [ArbSys, argsOffset, argsSize, retOffset, retSize]
+  ;; gas, this is more than enough
+  push 5000       ;; [gas, ArbSys, argsOffset, argsSize, retOffset, retSize]
+
+  ;; store the function selector
+  push 0xa3b1b31d ;; [selector, gas, ArbSys, argsOffset, argsSize, retOffset, retSize]
+  push0           ;; [0, selector, gas, ArbSys, argsOffset, argsSize, retOffset, retSize]
+  mstore          ;; [gas, ArbSys, argsOffset, argsSize, retOffset, retSize]
+
+  ;; perform the call
+  staticcall      ;; [success]
+  iszero          ;; [!success]
+  jumpi @throw    ;; []
+
+  ;; push the result onto the stack
+  push0           ;; [0]
+  mload           ;; [arbBlockNumber]
+}
+
 ;; ----------------------------------------------------------------------------
 ;; MACROS END -----------------------------------------------------------------
 ;; ----------------------------------------------------------------------------
@@ -48,7 +89,7 @@
   push 0            ;; [0]
   calldataload      ;; [input]
   push 1            ;; [1, input]
-  number            ;; [number, 1, input]
+  %arb_block_num    ;; [number, 1, input]
   sub               ;; [number-1, input]              
   dup2              ;; [input, number-1, input]
   gt                ;; [input > number-1, input]
@@ -59,7 +100,7 @@
   ;; there will be no overflow during the subtraction of number - input.
   push BUFLEN       ;; [buflen, input]
   dup2              ;; [input, buflen, input]
-  number            ;; [number, input, buflen, input]
+  %arb_block_num    ;; [number, input, buflen, input]
   sub               ;; [number - input, buflen, input]
   gt                ;; [number - input > buflen, input]
   jumpi @throw      ;; [input]
@@ -88,7 +129,7 @@ submit:
   calldataload      ;; [in]
   push BUFLEN       ;; [buflen, in]
   push 1            ;; [1, buflen, in]
-  number            ;; [number, 1, buflen, in]
+  %arb_block_num    ;; [number, 1, buflen, in]
   sub               ;; [number-1, buflen, in]
   mod               ;; [number-1 % buflen, in]
   sstore

--- a/src/execution_hash/main.eas
+++ b/src/execution_hash/main.eas
@@ -14,7 +14,9 @@
 ;; ----------------------------------------------------------------------------
 
 ;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
-#define BUFLEN = 8191
+;; was 8191, which is 8191*12 = 98292 seconds
+;; 98292 seconds is 98292 * 4 = 393168 L2 blocks
+#define BUFLEN = 393168 
 
 ;; SYSADDR is the address which calls the contract to submit a new block hash.
 #define SYSADDR = .address(0xfffffffffffffffffffffffffffffffffffffffe)

--- a/test/ExecutionHash.t.sol
+++ b/test/ExecutionHash.t.sol
@@ -10,8 +10,23 @@ address constant sysaddr = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
 uint256 constant buflen = 393168;
 bytes32 constant hash    = hex"88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6";
 
+contract ArbSys {
+    uint256 public arbBlockNumber;
+    function _roll(uint256 number) external {
+        arbBlockNumber = number;
+    }
+}
+
+function roll(uint256 number) {
+  ArbSys(address(100))._roll(number);
+}
+
+function blockNumber() view returns (uint256) {
+  return ArbSys(address(100)).arbBlockNumber();
+}
+
 function lastBlockNumber() view returns (bytes32) {
-  return bytes32(uint256(block.number)-1);
+  return bytes32(uint256(blockNumber())-1);
 }
 
 function hash_idx() view returns (bytes32) {
@@ -21,6 +36,8 @@ function hash_idx() view returns (bytes32) {
 contract ContractTest is Test {
     function setUp() public {
         vm.etch(addr, Geas.compile("src/execution_hash/main.eas"));
+        vm.etch(address(100), address(new ArbSys()).code);
+        roll(block.number);
     }
 
     // testRead verifies the contract returns the expected execution hash.
@@ -56,14 +73,14 @@ contract ContractTest is Test {
 
     function testReadBadBlockNumbers() public {
         // Set reasonable block number.
-        vm.roll(21053500);
-        uint256 number = block.number-1;
+        roll(21053500);
+        uint256 number = blockNumber()-1;
 
         // Store hash at expected indexes.
         vm.store(addr, hash_idx(), hash);
 
         // Request current block.
-        (bool ret, bytes memory data) = addr.call(bytes.concat(bytes32(block.number)));
+        (bool ret, bytes memory data) = addr.call(bytes.concat(bytes32(blockNumber())));
         assertFalse(ret);
         assertEq(data, hex"");
 
@@ -101,7 +118,7 @@ contract ContractTest is Test {
     // values.
     function testRingBuffers() public {
         // Set reasonable block number.
-        vm.roll(21053500);
+        roll(21053500);
 
         for (uint256 i = 0; i < 10000; i += 1) {
             bytes32 pbbr = bytes32(i*1337);
@@ -119,16 +136,16 @@ contract ContractTest is Test {
             assertEq(data, bytes.concat(pbbr));
 
             // Skip forward 1 block.
-            vm.roll(block.number+1);
+            roll(blockNumber()+1);
         }
     }
 
 
     // testHistoricalReads verifies that it is possible to read all previously
     // saved values in the beacon hash contract.
-    function testHistoricalReads() public {
+    function testHistoricalReads() public noGasMetering {
         uint256 start = 1;
-        vm.roll(start);
+        roll(start);
 
         // Saturate storage with fake hashs.
         for (uint256 i = 0; i < buflen; i += 1) {
@@ -139,7 +156,7 @@ contract ContractTest is Test {
             assertEq(data, hex"");
             if (i+1 < buflen) {
               // Only bump block number if not last iteration.
-              vm.roll(block.number+1);
+              roll(blockNumber()+1);
             }
         }
 

--- a/test/ExecutionHash.t.sol
+++ b/test/ExecutionHash.t.sol
@@ -7,7 +7,7 @@ import "../src/Contract.sol";
 
 address constant addr = 0x000000000000000000000000000000000000aaaa;
 address constant sysaddr = 0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
-uint256 constant buflen = 8191;
+uint256 constant buflen = 393168;
 bytes32 constant hash    = hex"88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6";
 
 function lastBlockNumber() view returns (bytes32) {


### PR DESCRIPTION
updated the ring buffer size to `393168`. assuming L2 block time of 250ms and L1 block time of 12s, then the amount of time that the buffer covers on L2 is equivalent to L1.

the following assembles the modified system contract bytecode that should exist at `0x0000F90827F1C53a10cb7A02335B175320002935`

```
geas src/execution_hash/main.eas
3373fffffffffffffffffffffffffffffffffffffffe14604857602036036044575f356001430381116044576205ffd0814303116044576205ffd09006545f5260205ff35b5f5ffd5b5f356205ffd060014303065500
```